### PR TITLE
fix(SessionCredential): 变更expiredTime类型为number

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,7 @@ export type Secret = {
 export type SessionCredential = {
   tmpSecretId: string;
   tmpSecretKey: string;
-  expiredTime: string;
+  expiredTime: number;
   sessionToken: string;
 }
 
@@ -92,6 +92,9 @@ class COSTransferManagerService {
       cosModule.initWithSessionCredentialCallback(configurations)
       this.emitter.addListener("COSUpdateSessionCredential", async () => {
         const credential = await callback()
+        if (credential.expiredTime && typeof credential.expiredTime !== 'number') {
+          credential.expiredTime = parseInt(credential.expiredTime)
+        }
         cosModule.updateSessionCredential(credential)
       });
     } else {


### PR DESCRIPTION
## 问题描述

在SessionCredential中expiredTime的类型被定义为string，官方文档中也同样为string，但在iOS、Android的代码中，都是以Int去Json中取值，出现了`RCTConvert JSON value '1601378001' of type NSString cannot be converted to NSNumber` 的错误，造成文件上传失败。

iOS中使用的 `RCTConvert int`
https://github.com/tencentyun/cos-xml-react-native/blob/85f12409dd4a4351c4cd366ecedd1ef07cceb00e/ios/CosXmlReactNative.m#L62

Android中使用的 `safeGetInt`
https://github.com/tencentyun/cos-xml-react-native/blob/85f12409dd4a4351c4cd366ecedd1ef07cceb00e/android/src/main/java/com/cosxmlreactnative/CosXmlReactNativeModule.java#L113

## 解决方案

- 将 `SessionCredential.expiredTime` 类型变更为 `number`
- 在调用 `initWithSessionCredentialCallback` 时，若 `expiredTime` 不为 `number` 则转换为 `int`
